### PR TITLE
bump package version and dependency library

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "google-webfonts-json-encoder",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "\"Given a list of available google font subsets and families, download the specified family, subset and variants, in several formats, encoding them as json\"",
   "main": "index.js",
   "scripts": {
@@ -22,7 +22,7 @@
   "dependencies": {
     "async": "^0.9.0",
     "request": "^2.55.0",
-    "ttf2woff": "^1.3.0",
+    "ttf2woff": "^2.0.1",
     "yamljs": "^0.2.1",
     "yargs": "^3.6.0"
   },


### PR DESCRIPTION
### Details
- **Jira ticket:** https://basekit.jira.com/browse/DEV-16263
- **Feature Environment URL:**
- **Affected versions:**

### Description of change
The security concern, _**Regular Expression Denial of Service**_,  is related to the dependency library,  ttf2woff > argparse >  underscore.string, which is being used in the package (google-webfonts-json-encoder). The fix is to update ttf2woff package to the latest version and the package, underscore.string, will no longer be its dependency and hopefully the vulnerability should be resolved.