### PR TITLE
Replace request with node-fetch

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -1,37 +1,40 @@
 'use strict';
-
-const request = require('request');
+const fetch = (...args) => import('node-fetch').then(({default: fetch}) => fetch(...args));
+const { pipeline } = require('stream');
+const { promisify } = require('util');
 
 // apiParams = { endpoint, apiParam, apiValue }
 function requestList (apiParams) {
-    return new Promise((resolve, reject) => {
-        request(requestParams(apiParams), (err, response, body) => {
-            if (err) {
-                return reject(err);
-            }
-            resolve(JSON.parse(body).items);
-        });
+    const [url, params] = requestParams(apiParams);
+    return new Promise(async (resolve, reject) => {
+        try {
+            const response = await fetch(url, params);
+            const data = await response.json();
+            resolve(data.items);
+        } catch (error) {
+            reject(error);
+        }
     });
 }
 
-function requestFile (url, callback) {
-    return request(url, callback);
+async function requestFile (url, fileStream) {
+    const streamPipeline = promisify(pipeline);
+    const response = await fetch(url);
+    await streamPipeline(response.body, fileStream);
 }
 
 function requestParams (apiParams) {
     let params = {
-        uri: apiParams.endpoint,
         method: 'GET',
-        qs: {}
     };
 
-    params.qs[apiParams.keyParam] = keyValue(apiParams.keyEnv);
+    const url = `${apiParams.endpoint}?${apiParams.keyParam}=${keyValue(apiParams.keyEnv)}`;
 
-    if (!params.qs[apiParams.keyParam]) {
+    if (!keyValue(apiParams.keyEnv)) {
         throw new Error('No Google API key found');
     }
 
-    return params;
+    return [url, params];
 }
 
 function keyValue (varName) {

--- a/lib/fontRequester.js
+++ b/lib/fontRequester.js
@@ -99,8 +99,7 @@ function downloadFonts (options, available) {
                         return fileCallback(error);
                     }
                 });
-                api.requestFile(url)
-                    .pipe(file);
+                api.requestFile(url, file);
             }, (err) => {
                 callback(err);
             });

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "homepage": "https://github.com/basekit/google-webfonts-json-encoder",
   "dependencies": {
     "async": "^0.9.0",
-    "request": "^2.55.0",
+    "node-fetch": "^3.3.2",
     "ttf2woff": "^2.0.1",
     "yamljs": "^0.2.1",
     "yargs": "^3.6.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "google-webfonts-json-encoder",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "\"Given a list of available google font subsets and families, download the specified family, subset and variants, in several formats, encoding them as json\"",
   "main": "index.js",
   "scripts": {

--- a/test/lib/api.test.js
+++ b/test/lib/api.test.js
@@ -7,13 +7,13 @@ describe('api', function () {
 
     describe('requestList', function () {
         it('returns an error if no Google API Key is passed as a param', function (done) {
-            const request = function () {};
+            const fetch = function () {};
 
             mockery.enable({
                 warnOnUnregistered: false
             });
 
-            mockery.registerMock('request', request);
+            mockery.registerMock('node-fetch', fetch);
             const requestList = require('../../lib/api').requestList;
             const apiParams = {
                 endpoint: 'http://www.example.com',
@@ -21,11 +21,10 @@ describe('api', function () {
                 keyEnv: 'this_test_GOOGLE_API_KEY'
             };
 
-            requestList(apiParams).catch((err) => {
-                assert.equal(err.message, 'No Google API key found');
-                mockery.disable();
-                done();
-            });
+            assert.throws(() => requestList(apiParams), /No Google API key found/);
+
+            mockery.disable();
+            done();
         });
     });
 });


### PR DESCRIPTION
This (hopefully) fixes a dependabot issue in the main basekit branch by removing a deprecated dependency (request) and replacing it with node-fetch.